### PR TITLE
Add get_torrent_progress method and TorrentProgress model

### DIFF
--- a/seedrcc/_base.py
+++ b/seedrcc/_base.py
@@ -124,6 +124,11 @@ class BaseClient(ABC):
         pass
 
     @abstractmethod
+    def get_torrent_progress(self, progress_url: str) -> "models.TorrentProgress":
+        """Fetch and parse the progress data for an active torrent download."""
+        pass
+
+    @abstractmethod
     def change_name(self, name: str, password: str) -> "models.APIResult":
         """Change the name of the account."""
         pass

--- a/seedrcc/async_client.py
+++ b/seedrcc/async_client.py
@@ -619,6 +619,33 @@ class AsyncSeedr(BaseClient):
         devices_data = response_data.get("devices", [])
         return [models.Device.from_dict(d) for d in devices_data]
 
+    async def get_torrent_progress(self, progress_url: str) -> models.TorrentProgress:
+        """
+        Fetch and parse the progress data for an active torrent download.
+
+        Args:
+            progress_url (str): The progress URL from a `Torrent` object's `progress_url` field.
+
+        Returns:
+            A `TorrentProgress` object containing download stats.
+
+        Example:
+            ```python
+            contents = await client.list_contents()
+            for torrent in contents.torrents:
+                if torrent.progress_url:
+                    progress = await client.get_torrent_progress(torrent.progress_url)
+                    print(f"{progress.title}: {progress.progress:.1f}%")
+            ```
+        """
+        url = httpx.URL(progress_url).copy_remove_param("callback")
+        response = await self._make_http_request(self._client, "get", str(url))
+        try:
+            data = response.json()
+        except json.JSONDecodeError as e:
+            raise APIError("Invalid JSON response from progress URL.", response=response) from e
+        return models.TorrentProgress.from_dict(data)
+
     async def change_name(self, name: str, password: str) -> models.APIResult:
         """
         Change the name of the account.

--- a/seedrcc/client.py
+++ b/seedrcc/client.py
@@ -610,6 +610,33 @@ class Seedr(BaseClient):
         devices_data = response_data.get("devices", [])
         return [models.Device.from_dict(d) for d in devices_data]
 
+    def get_torrent_progress(self, progress_url: str) -> models.TorrentProgress:
+        """
+        Fetch and parse the progress data for an active torrent download.
+
+        Args:
+            progress_url (str): The progress URL from a `Torrent` object's `progress_url` field.
+
+        Returns:
+            A `TorrentProgress` object containing download stats.
+
+        Example:
+            ```python
+            contents = client.list_contents()
+            for torrent in contents.torrents:
+                if torrent.progress_url:
+                    progress = client.get_torrent_progress(torrent.progress_url)
+                    print(f"{progress.title}: {progress.progress:.1f}%")
+            ```
+        """
+        url = httpx.URL(progress_url).copy_remove_param("callback")
+        response = self._make_http_request(self._client, "get", str(url))
+        try:
+            data = response.json()
+        except json.JSONDecodeError as e:
+            raise APIError("Invalid JSON response from progress URL.", response=response) from e
+        return models.TorrentProgress.from_dict(data)
+
     def change_name(self, name: str, password: str) -> models.APIResult:
         """
         Change the name of the account.

--- a/seedrcc/models.py
+++ b/seedrcc/models.py
@@ -22,6 +22,8 @@ __all__ = [
     "RefreshTokenResult",
     "ScannedTorrent",
     "ScanPageResult",
+    "TorrentProgressStats",
+    "TorrentProgress",
 ]
 
 
@@ -388,3 +390,58 @@ class APIResult(_BaseModel):
 
     result: bool
     code: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class TorrentProgressStats(_BaseModel):
+    """Represents the nested 'stats' object in a torrent progress response."""
+
+    torrent_hash: str = ""
+    progress: float = 0.0
+    title: str = ""
+    downloading_from: int = 0
+    uploading_to: int = 0
+    warnings: str = ""
+    stopped: int = 0
+    folder_created: int = 0
+    download_rate: int = 0
+    size: int = 0
+    torrent_quality: Optional[int] = None
+    seeders: int = 0
+    leechers: int = 0
+    seed_ratio: float = 0.0
+
+
+@dataclass(frozen=True)
+class TorrentProgress(_BaseModel):
+    """Represents the progress data for an active torrent download."""
+
+    title: str
+    size: int
+    progress: float
+    hash: str
+    stopped: int
+    download_rate: int
+    folder_created: int
+    stats: TorrentProgressStats
+    torrent_quality: Optional[int] = None
+    warnings: str = ""
+    files_progress: List[Any] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "TorrentProgress":
+        instance = cls(
+            title=data.get("title", ""),
+            size=data.get("size", 0),
+            progress=data.get("progress", 0.0),
+            hash=data.get("hash", ""),
+            stopped=data.get("stopped", 0),
+            download_rate=data.get("download_rate", 0),
+            folder_created=data.get("folder_created", 0),
+            stats=TorrentProgressStats.from_dict(data.get("stats", {})),
+            torrent_quality=data.get("torrent_quality"),
+            warnings=data.get("warnings", ""),
+            files_progress=data.get("files_progress", []),
+        )
+        object.__setattr__(instance, "_raw", data)
+        return instance

--- a/seedrcc/models.py
+++ b/seedrcc/models.py
@@ -404,7 +404,7 @@ class TorrentProgressStats(_BaseModel):
     warnings: str = ""
     stopped: int = 0
     folder_created: int = 0
-    download_rate: int = 0
+    download_rate: float = 0.0
     size: int = 0
     torrent_quality: Optional[int] = None
     seeders: int = 0
@@ -421,8 +421,7 @@ class TorrentProgress(_BaseModel):
     progress: float
     hash: str
     stopped: int
-    download_rate: int
-    folder_created: int
+    download_rate: float
     stats: TorrentProgressStats
     torrent_quality: Optional[int] = None
     warnings: str = ""
@@ -437,7 +436,6 @@ class TorrentProgress(_BaseModel):
             hash=data.get("hash", ""),
             stopped=data.get("stopped", 0),
             download_rate=data.get("download_rate", 0),
-            folder_created=data.get("folder_created", 0),
             stats=TorrentProgressStats.from_dict(data.get("stats", {})),
             torrent_quality=data.get("torrent_quality"),
             warnings=data.get("warnings", ""),


### PR DESCRIPTION
## Summary

- Adds `TorrentProgressStats` and `TorrentProgress` models to parse the torrent progress response
- Adds `get_torrent_progress(progress_url)` method to `Seedr`, `AsyncSeedr`, and `BaseClient`
- Strips the `callback` query parameter from the progress URL to receive plain JSON instead of JSONP